### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,57 @@ import { FixedSizeList as List } from 'react-window'
 import AutoSizer from 'react-virtualized-auto-sizer'
 import InfiniteLoader from 'react-window-infinite-loader'
 
+const InfiniteLoading = forwardRef(
+  (
+    {
+      children,
+      hasMoreItems,
+      itemsCount,
+      itemHeight,
+      loadMoreItems,
+      placeholder
+    },
+    ref,
+  ) => {
+    let effectiveCount = itemsCount
+    if (effectiveCount === undefined) {
+        effectiveCount = hasMoreItems ? children.length + 1 : children.length
+    }
+
+    const isItemLoaded = index => !hasMoreItems || index < children.length
+
+    return (
+      <AutoSizer>
+        {({ height, width }) => (
+          <InfiniteLoader
+            isItemLoaded={isItemLoaded}
+            itemCount={effectiveCount}
+            loadMoreItems={loadMoreItems}
+            ref={ref}
+          >
+            {({ onItemsRendered, ref }) => (
+              <List
+                height={height}
+                itemCount={effectiveCount}
+                itemSize={itemHeight}
+                onItemsRendered={onItemsRendered}
+                ref={ref}
+                width={width}
+              >
+                {({ index, style }) => (
+                  <div style={style}>
+                    {children[index] != null ? children[index] : placeholder}
+                  </div>
+                )}
+              </List>
+            )}
+          </InfiniteLoader>
+        )}
+      </AutoSizer>
+    )
+  }
+)
+
 InfiniteLoading.propTypes = {
   hasMoreItems: PropTypes.bool,
   loadMoreItems: PropTypes.func,
@@ -19,50 +70,5 @@ InfiniteLoading.defaultProps = {
   loadMoreItems: () => {}
 }
 
-function InfiniteLoading({
-  children,
-  hasMoreItems,
-  itemsCount,
-  itemHeight,
-  loadMoreItems,
-  placeholder
-}, ref) {
-  let effectiveCount = itemsCount
-  if (effectiveCount === undefined) {
-      effectiveCount = hasMoreItems ? children.length + 1 : children.length
-  }
+export default InfiniteLoading
 
-  const isItemLoaded = index => !hasMoreItems || index < children.length
-
-  return (
-    <AutoSizer>
-      {({ height, width }) => (
-        <InfiniteLoader
-          isItemLoaded={isItemLoaded}
-          itemCount={effectiveCount}
-          loadMoreItems={loadMoreItems}
-          ref={ref}
-        >
-          {({ onItemsRendered, ref }) => (
-            <List
-              height={height}
-              itemCount={effectiveCount}
-              itemSize={itemHeight}
-              onItemsRendered={onItemsRendered}
-              ref={ref}
-              width={width}
-            >
-              {({ index, style }) => (
-                <div style={style}>
-                  {children[index] != null ? children[index] : placeholder}
-                </div>
-              )}
-            </List>
-          )}
-        </InfiniteLoader>
-      )}
-    </AutoSizer>
-  )
-}
-
-export default forwardRef(InfiniteLoading)


### PR DESCRIPTION
gets rid of the following warning:
```
Warning: forwardRef render functions do not support propTypes or defaultProps. Did you accidentally pass a React component?

```