### PR TITLE
:sparkles: Add an elementClassName prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ function Example({ items, fetchMore, hasMore }) {
 | loadMoreItems | no       | function | A function that will be called each time the list need to load more items.                                                                                                                                |
 | placeholder   | no       | node     | Any render-able value like strings or React.Nodes to be displayed while `children` is loading                                                                                                             |
 | customScrollbar   | no       | boolean     | A boolean that determines if [react-custom-scrollbars](https://github.com/malte-wessel/react-custom-scrollbars) is used instead of native one                                                      |
+| elementClassName   | no       | string     | A React className prop that will be applied to every child container
 | ref   | no       | ref or function     | A ref or a callback ref to get component instance so you can call instance's methods (see [Methods section](/README.md#methods))                                                     |
 
 ## Methods

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,8 @@ class InfiniteLoading extends Component {
     children: PropTypes.array.isRequired,
     itemHeight: PropTypes.number.isRequired,
     placeholder: PropTypes.node,
-    customScrollbar: PropTypes.bool
+    customScrollbar: PropTypes.bool,
+    elementClassName: PropTypes.string
   }
 
   constructor(props) {
@@ -59,7 +60,8 @@ class InfiniteLoading extends Component {
       itemHeight,
       loadMoreItems,
       placeholder,
-      customScrollbar
+      customScrollbar,
+      elementClassName
     } = this.props
 
     let effectiveCount = itemsCount
@@ -92,7 +94,7 @@ class InfiniteLoading extends Component {
                 outerElementType={customScrollbar ? CustomScrollbarsVirtualList : null}
               >
                 {({ index, style }) => (
-                  <div style={style}>
+                  <div className={elementClassName} style={style}>
                     {children[index] != null ? children[index] : placeholder}
                   </div>
                 )}


### PR DESCRIPTION
Hi,

I recently ran into a peculiar issue, I need to modify the `z-index` of a child container, when the user is hovering it, so the shadow of said child is visible all around it.

The easier way I can think of doing so, as css selectors still won't let you target the parent element, is to pass a `className` to the container of each child.

And so I am opening this PR, as it might also be helpful for others.

Cheers.